### PR TITLE
Allow for multiple comment chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Decoding params
 
 |      name        | type       | defaut value |            description                                                          |
 |------------------|------------|--------------|---------------------------------------------------------------------------------|
-| **comment**      | `string`   | `;`          | String for start of comment                                                     |
+| **comment**      | `string \| string[]` | `;` | String for start of comment                                                     |
 | **delimiter**    | `string`   | `=`          | Delimiter between key and value                                                 |
 | **nothrow**      | `boolean`  | `false`      | Use field `Symbol('Errors of parsing')` instead `throw`                         |
 | **autoTyping**   | `boolean`  | `true`       | Try to auto translate strings to another values (translation map below)         |

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -11,7 +11,7 @@ import { ICustomTyping } from './interfaces/custom-typing';
 import { $Proto } from './proto';
 
 export interface IParseConfig {
-  comment?: string;
+  comment?: string | string[];
   delimiter?: string;
   nothrow?: boolean;
   autoTyping?: boolean | ICustomTyping;
@@ -42,11 +42,12 @@ export function parse(data: string, params?: IParseConfig): IIniObject {
   let currentSection: string = '';
   let isDataSection: boolean = false;
   const result: IIniObject = {};
+  const commentChars: string[] = Array.isArray(comment) ? comment : [comment];
 
   for (const rawLine of lines) {
     lineNumber += 1;
     const line: string = rawLine.trim();
-    if ((line.length === 0) || (line.startsWith(comment))) {
+    if ((line.length === 0) || commentChars.some((char) => line.startsWith(char))) {
       continue;
     } else if (line[0] === '[') {
       const match = line.match(sectionNameRegex);

--- a/test/test.ts
+++ b/test/test.ts
@@ -96,6 +96,19 @@ isNULL = null
 isUndefined =
 `;
 
+const ini9 = `v1 : 2
+v-2:true
+v 3 : string
+[smbd]
+v1:5
+v2 : what
+#comment
+;other comment
+v5 : who is who = who
+
+[test scope with spaces]
+mgm*1  : 2.5`;
+
 const v1 = {
   v1: 2,
   'v-2': true,
@@ -143,6 +156,8 @@ test('ini parsing', () => {
   expect(parse(ini1)).toEqual(v1);
 
   expect(parse(ini2, { comment: '#', delimiter: ':' })).toEqual(v1);
+
+  expect(parse(ini9, { comment: ['#', ';'], delimiter: ':' })).toEqual(v1);
 
   expect(parse(ini2, { comment: '#', delimiter: ':', autoTyping: false })).toEqual(v2);
 


### PR DESCRIPTION
Certain INI formats support multiple comment types, for example
[EditorConfig][0]. This changes the signature of IParseConfig.comment to
accept an array of strings as well, in order to support multiple comment
types.

Fixes https://github.com/Sdju/js-ini/issues/18

[0]: https://editorconfig-specification.readthedocs.io/#file-format