### PR TITLE
feat(stringify): support array for multiple value

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -49,6 +49,10 @@ export function stringify(data: IIniObject, params?: IStringifyConfig): string {
         if (!sectionKeys) {
           break;
         }
+      } else if (sectionKeys && Array.isArray(val)) {
+        val.forEach((item) => {
+          chunks.push(formatPare(curKey, item.toString()));
+        });
       } else if (typeof val === 'object') {
         if (sectionKeys) {
           throw new Error('too much nesting');

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -149,6 +149,11 @@ second = 1
 second = 2
 another = 1`;
 
+const ini12 = `
+[hello]
+fooKey=value1
+fooKey=value2`;
+
 const v1 = {
   v1: 2,
   'v-2': true,
@@ -189,6 +194,12 @@ const v3 = {
     'qpo[weiktjkgtjgiqewrjgoepqrg',
     'qwlfp-[weklfpowek,mf',
   ],
+};
+
+const v4 = {
+  hello: {
+    fooKey: ['value1', 'value2'],
+  },
 };
 
 describe('base js-ini test', () => {
@@ -250,6 +261,15 @@ describe('base js-ini test', () => {
       dataSections: ['test scope with data'],
       autoTyping: false,
     })).toEqual(v3);
+  });
+
+  it('ini stringify multiple value', () => {
+    // identity
+    expect(parse(stringify(v4), {
+      keyMergeStrategy: 'join-to-array',
+    })).toEqual(v4);
+    // stringify
+    expect(stringify(v4)).toBe(ini12);
   });
 
   it('ini parsing: proto', () => {


### PR DESCRIPTION
Great lib!

I encountered a small issue when trying to stringify an object, I wanted to create something like the following

```ini
[Section]
foo=value1
foo=value2
```

But the only way I found to do it was the following

```ts
import { stringify } from 'js-ini';

stringify({'Section': ["foo=value1", "foo=value2"]});
```

It works, but I think the following synthax would be easier to use

```ts
import { stringify } from 'js-ini';

stringify({'Container': {
    foo: ["value1", "value2"],
}});
```

As I am using this library for the amazing `join-to-array` option for duplicates, I think we should be able to use the same synthax to stringify than the synthax we get when we use this option.

- [x] I added tests to ensure the expected behavior