### PR TITLE
feat(parsing): handle user parsing error

### DIFF
--- a/src/errors/parsing-error.ts
+++ b/src/errors/parsing-error.ts
@@ -1,6 +1,6 @@
 export class ParsingError extends Error {
-  constructor(line: string, lineNumber: number) {
-    super(`Unsupported type of line: [${lineNumber}] "${line}"`);
+  constructor(line: string, lineNumber: number, message?: string) {
+    super(message ?? `Unsupported type of line: [${lineNumber}] "${line}"`);
     this.line = line;
     this.lineNumber = lineNumber;
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -91,7 +91,29 @@ export function parse(data: string, params?: IParseConfig): IIniObject {
       const posOfDelimiter = line.indexOf(delimiter);
       const name = line.slice(0, posOfDelimiter).trim();
       const rawVal = line.slice(posOfDelimiter + 1).trim();
-      const val = typeParser(rawVal, currentSection, name);
+
+      let val: any;
+      try {
+        val = typeParser(rawVal, currentSection, name);
+      } catch (err: unknown) {
+        let error: ParsingError;
+        // if thrown error is instance of Error using its message
+        if (err instanceof Error) {
+          error = new ParsingError(line, lineNumber, err.message);
+        } else {
+          error = new ParsingError(line, lineNumber);
+        }
+
+        if (!nothrow) {
+          throw error;
+        } else if ($Errors in result) {
+          (result[$Errors] as ParsingError[]).push(error);
+        } else {
+          result[$Errors] = [error];
+        }
+        continue;
+      }
+
       const section = (currentSection !== '') ? (result[currentSection] as IIniObjectSection) : result;
       if (isOverrideStrategy) {
         section[name] = val;

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -325,6 +325,31 @@ describe('base js-ini test', () => {
       });
   });
 
+  it('autotype throwing an error should be converted to ParseError', () => {
+    expect(() => {
+      parse(ini8, {
+        autoTyping: () => {
+          throw new Error('dummy error');
+        },
+      });
+    }).toThrowError('dummy error');
+  });
+
+  it('autotype throwing an error with nothrow to true should aggregate the errors', () => {
+    expect(parse(ini6, {
+      nothrow: true,
+      protoSymbol: true,
+      autoTyping: () => {
+        throw new Error('dummy error');
+      },
+    })).toEqual({
+      [$Proto]: {}, // no section has nothing was parsed successfully
+      [$Errors]: [
+        new ParsingError('polluted = "polluted"', 3, 'dummy error'),
+      ],
+    });
+  });
+
   it('ini stringify: infinity fix test', () => {
     const result = parse(ini10);
     stringify(result);


### PR DESCRIPTION
## Description

As per documentation, we can define a `autoTyping` with the following

```ts
import { parse } from 'js-ini';

const ACCEPTED = ['hello', 'world'];

const content = parse(<string>, {
  autoTyping: (val, section, key) => {
    if (key in ACCEPTED) return val;
    throw new Error(`key ${key} is not valid in section ${section}`);
  },
});
```

 It can be useful to throw an error in this function to ensure the type safety of the content parsed. But above all, when parsing the `ParsingError` is very valuable as it contains `lineNumber` information.

Wrapping the user error in a ParsingError improving the parsing capabilities.

## Background

I am writing a Language Service for a specific format derived from the `.ini`, and having a nice way to collect all parsing error is very valuable.

 cc @Sdju