### PR TITLE
fix(stringify): emit root-level keys before sections

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -33,7 +33,14 @@ export function stringify(data: IIniObject, params?: IStringifyConfig): string {
   let sectionKeys: string[] | null = null;
   let curKeyId: number = 0;
 
-  for (const key of Object.keys(data)) {
+  // Root-level keys must be emitted before any [section] header, otherwise a
+  // scalar key declared after a section ends up inside that section on parse.
+  const orderedKeys: string[] = [
+    ...Object.keys(data).filter((key) => typeof data[key] !== 'object'),
+    ...Object.keys(data).filter((key) => typeof data[key] === 'object'),
+  ];
+
+  for (const key of orderedKeys) {
     while (!sectionKeys || (sectionKeys.length !== curKeyId)) {
       let curKey: string;
       if (sectionKeys) {

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -272,6 +272,16 @@ describe('base js-ini test', () => {
     expect(stringify(v4)).toBe(ini12);
   });
 
+  it('ini stringify: root keys are emitted before sections', () => {
+    const obj = {
+      section: { inner: 'a' },
+      root: 'b',
+    };
+    // A root-level key declared after a section must round-trip back to the
+    // root, not be absorbed into the preceding section.
+    expect(parse(stringify(obj), { autoTyping: false })).toEqual(obj);
+  });
+
   it('ini parsing: proto', () => {
     expect(() => parse(ini6))
       .toThrow('Unsupported section name "__proto__": [2]"');


### PR DESCRIPTION
### Problem

`stringify` writes object keys in their original order, so a root-level key that comes after a nested object is written underneath that object's `[section]` header. When the output is read back with `parse`, the root key is absorbed into the section instead of staying at the top level, so `parse(stringify(obj))` does not return `obj`:

```js
import { parse, stringify } from 'js-ini';

const obj = { section: { inner: 'a' }, root: 'b' };

stringify(obj);
// "\n[section]\ninner=a\nroot=b"

parse(stringify(obj), { autoTyping: false });
// { section: { inner: 'a', root: 'b' } }   <-- "root" moved into [section]
```

### Cause

In an INI document every key after a `[section]` header belongs to that section, so root-level keys can only be represented before the first section. `stringify` iterates `Object.keys(data)` in insertion order, which can place a root key after a section that was declared earlier in the object.

### Fix

Order the top-level keys so non-object (scalar) keys are written before any object/array section. Relative order within each group is preserved, and output is unchanged for objects that already list their root keys first, so the existing fixtures and tests are unaffected. Added a test for the round trip.
